### PR TITLE
Fix misleading comment

### DIFF
--- a/3_types/5_structs/src/main.rs
+++ b/3_types/5_structs/src/main.rs
@@ -9,7 +9,7 @@ pub struct InvulnerablePlayer {
 }
 
 fn main() {
-    //1 - Should construct a new Player object from name and health, and print debug info
+    //1 - Should construct a new Player object from health, and print debug info
 
     let mut mario = Player::new(100);
     assert_eq!(format!("{:?}", mario), "Player { items: [], health: 100 }");


### PR DESCRIPTION
Remove the reference to the non-existent variable `name`.